### PR TITLE
Correct INSTALL.txt instructions for Windows

### DIFF
--- a/tensorflow-mnist-tutorial/INSTALL.txt
+++ b/tensorflow-mnist-tutorial/INSTALL.txt
@@ -27,13 +27,10 @@ Ubuntu/Linux:
 Windows:
 	Install Anaconda, Python 3 version: https://www.continuum.io/downloads#windows
 	Anaconda comes with matplotlib built in.
-	In the Anaconda shell type: pip install --upgrade tensorflow
-		If you get the error "Could not find a version that satisfies the requirement (...)" try the following alternative:
-		conda config --add channels conda-forge
-		conda install tensorflow
+	In the Anaconda shell type: conda install tensorflow
 
 TEST YOUR INSTALLATION:
     git clone https://github.com/martin-gorner/tensorflow-mnist-tutorial.git
     cd tensorflow-mnist-tutorial
-    python3 mnist_1.0_softmax.py
+    python mnist_1.0_softmax.py
     => A window should appear displaying a graphical visualisation and you should also see training data in the terminal.


### PR DESCRIPTION
After following the instructions on a Windows 10 machine without GPU support, I encountered the issue described here: https://github.com/tensorflow/tensorflow/issues/17393 
I also found the fix at that same location.  Also, when running mnist_1.0_softmax.py in the Anaconda shell, I had to use "python" instead of "python3".