### PR TITLE
Update repository address

### DIFF
--- a/tensorflow-mnist-tutorial/INSTALL.txt
+++ b/tensorflow-mnist-tutorial/INSTALL.txt
@@ -33,7 +33,7 @@ Windows:
 		conda install tensorflow
 
 TEST YOUR INSTALLATION:
-    git clone https://github.com/martin-gorner/tensorflow-mnist-tutorial.git
-    cd tensorflow-mnist-tutorial
+    git clone https://github.com/GoogleCloudPlatform/tensorflow-without-a-phd.git
+    cd tensorflow-without-a-phd/tensorflow-mnist-tutorial
     python3 mnist_1.0_softmax.py
     => A window should appear displaying a graphical visualisation and you should also see training data in the terminal.


### PR DESCRIPTION
The 'git clone' command refers to 'https://github.com/martin-gorner/tensorflow-mnist-tutorial.git' which is the old MNIST repository (and contains only README).