### PR TITLE
Tensorflow requires python 3.6, not latest (3.7)

### DIFF
--- a/tensorflow-mnist-tutorial/INSTALL.txt
+++ b/tensorflow-mnist-tutorial/INSTALL.txt
@@ -7,7 +7,11 @@ docker), please visit tensorflow.org and follow the Python 3 instructions.
 
 MacOS:
 	# If you do not have it already, install git from https://git-scm.com/download/mac
-	# Install the latest version of python 3 from https://www.python.org/downloads/
+	
+	# Install the latest version of python 3.6 from https://www.python.org/downloads/	
+	# Don't use 3.7 - it will result in an error:
+	# "Could not find a version that satisfies the requirement tensorflow" when you try to install tensorflow!
+	
 	# and run this on the command line so that python3 can access https:// URLs:
 	sudo /Applications/Python\ 3.6/Install\ Certificates.command
 	# Now you can install tensorflow and matplotlib


### PR DESCRIPTION
You'll get a "Could not find a version that satisfies the requirement tensorflow" when running 'pip3 install --upgrade tensorflow' using latest python, which is 3.7. 

See https://stackoverflow.com/questions/48720833/could-not-find-a-version-that-satisfies-the-requirement-tensorflow for details