### PR TITLE
Fixing decay call at plot_learning_rate method

### DIFF
--- a/tensorflow-mnist-tutorial/keras_02_mnist_dense.ipynb
+++ b/tensorflow-mnist-tutorial/keras_02_mnist_dense.ipynb
@@ -173,7 +173,7 @@
     "\n",
     "def plot_learning_rate(lr_func, epochs):\n",
     "  xx = np.arange(epochs+1, dtype=np.float)\n",
-    "  y = [lr_decay(x) for x in xx]\n",
+    "  y = [lr_func(x) for x in xx]\n",
     "  fig, ax = plt.subplots(figsize=(9, 6))\n",
     "  ax.set_xlabel('epochs')\n",
     "  ax.set_title('Learning rate\\ndecays from {:0.3g} to {:0.3g}'.format(y[0], y[-2]))\n",

--- a/tensorflow-mnist-tutorial/keras_03_mnist_dense_lrdecay_dropout.ipynb
+++ b/tensorflow-mnist-tutorial/keras_03_mnist_dense_lrdecay_dropout.ipynb
@@ -181,7 +181,7 @@
     "\n",
     "def plot_learning_rate(lr_func, epochs):\n",
     "  xx = np.arange(epochs+1, dtype=np.float)\n",
-    "  y = [lr_decay(x) for x in xx]\n",
+    "  y = [lr_func(x) for x in xx]\n",
     "  fig, ax = plt.subplots(figsize=(9, 6))\n",
     "  ax.set_xlabel('epochs')\n",
     "  ax.set_title('Learning rate\\ndecays from {:0.3g} to {:0.3g}'.format(y[0], y[-2]))\n",

--- a/tensorflow-mnist-tutorial/keras_04_mnist_convolutional.ipynb
+++ b/tensorflow-mnist-tutorial/keras_04_mnist_convolutional.ipynb
@@ -173,7 +173,7 @@
     "\n",
     "def plot_learning_rate(lr_func, epochs):\n",
     "  xx = np.arange(epochs+1, dtype=np.float)\n",
-    "  y = [lr_decay(x) for x in xx]\n",
+    "  y = [lr_func(x) for x in xx]\n",
     "  fig, ax = plt.subplots(figsize=(9, 6))\n",
     "  ax.set_xlabel('epochs')\n",
     "  ax.set_title('Learning rate\\ndecays from {:0.3g} to {:0.3g}'.format(y[0], y[-2]))\n",

--- a/tensorflow-mnist-tutorial/keras_05_mnist_batch_norm.ipynb
+++ b/tensorflow-mnist-tutorial/keras_05_mnist_batch_norm.ipynb
@@ -163,7 +163,7 @@
     "\n",
     "def plot_learning_rate(lr_func, epochs):\n",
     "  xx = np.arange(epochs+1, dtype=np.float)\n",
-    "  y = [lr_decay(x) for x in xx]\n",
+    "  y = [lr_func(x) for x in xx]\n",
     "  fig, ax = plt.subplots(figsize=(9, 6))\n",
     "  ax.set_xlabel('epochs')\n",
     "  ax.set_title('Learning rate\\ndecays from {:0.3g} to {:0.3g}'.format(y[0], y[-2]))\n",


### PR DESCRIPTION
Method `plot_learning_rate` was not using the `lr_func` parameter and was using the global definition of `lr_decay` instead. This PR fixes it by using the correct method parameter.