### PR TITLE
display_digits() is not working

### DIFF
--- a/tensorflow-mnist-tutorial/keras_01_mnist.ipynb
+++ b/tensorflow-mnist-tutorial/keras_01_mnist.ipynb
@@ -156,7 +156,7 @@
     "  digits = np.reshape(digits, [28, 28*n])\n",
     "  plt.yticks([])\n",
     "  plt.xticks([28*x+14 for x in range(n)], predictions)\n",
-    "  plt.grid(b=None)\n",
+    "  plt.grid(visible=None)\n",
     "  for i,t in enumerate(plt.gca().xaxis.get_ticklabels()):\n",
     "    if predictions[i] != labels[i]: t.set_color('red') # bad predictions in red\n",
     "  plt.imshow(digits)\n",


### PR DESCRIPTION
The notebook returns an error when try to use the display_digits() because the parameter `b` of grid was deprecated in [matplotlib 3.5](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#the-first-parameter-of-axes-grid-and-axis-grid-has-been-renamed-to-visible), and renamed `visible`.

This PR fix the #59 issue.

Reference: https://github.com/matplotlib/matplotlib/issues/25267#issuecomment-1437368645